### PR TITLE
fix: use localhost as default origin hostname

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - ORIGIN_SFU_URL=http://sfu:8280/conferences/
       - SFU_API_KEY=example
       - EDGE_LIST_CONFIG=/etc/edge-list-config.json
+      - HOSTNAME=${ORIGIN_HOST:-localhost}
     ports:
       - "8200:8200/tcp"
     extra_hosts:


### PR DESCRIPTION
For the WHIP endpoint (origin) to generate a valid WHIP resource in the response it needs to set the correct hostname. This PR addresses this by setting the default hostname to localhost. This can be overridden with the environment variable `ORIGIN_HOST`